### PR TITLE
New wes download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,15 @@ wes status --watch
     ```
     wes download -p https://wes-tes-example.tsi.ebi.ac.uk/data/tmp/Hello.txt
     ```
-
-
+* Download a file (with option to specify download location and filename):
+    ```
+    wes download --destination ./examples/readthis.md https://wes-tes-example.tsi.ebi.ac.uk/data/tmp/README.md
+    ```
+* Download a file (with option to specify filename):
+    ```
+    wes download --destination readthis.md https://wes-tes-example.tsi.ebi.ac.uk/data/tmp/README.md
+    ```
+    
 ### Run spec file
 
 The argument to `wes run` must be a yaml file with a specific format. You can find some examples [here](examples/).

--- a/src/WesCli/ArgParser.py
+++ b/src/WesCli/ArgParser.py
@@ -18,12 +18,16 @@ Usage:
     wes run <runSpec>
     wes status [-w|--watch]
     wes get <url>
-    wes download [-p] <url>
+    wes download [-p|--progress] [-d <location>|--destination=<location>] <url>
     wes upload <filename> <url>
 
 Options:
-  -h --help                          Shows this screen.
-  -p                                 Display progress bar when downloading file
+  -h --help                                                 Shows this screen.
+  -p --progress                                             Display progress bar when downloading file.
+  -d <location> --destination <location>                    Designate a destination when downloading file. User can
+                                                            specify a filename and directory for downloaded file to
+                                                            appear in.
+
 """
 
     return docopt(doc, argv=args)

--- a/src/WesCli/Get.py
+++ b/src/WesCli/Get.py
@@ -24,50 +24,50 @@ def formatEntry(e: DirEntry):
         "Name" : "0PR0GE"
     }
     '''
-    
+
     maybeSlash = '/' if e['IsDir'] else ''
-    
+
     return e['Name'] + maybeSlash
 
 
 def newFormatLine(wesUrl):
-    
+
     basePath = getPath(wesUrl)
-    
+
     def fileUrl(filename):
-        
+
         return f"file://{os.path.join(basePath, filename)}"
 
 
     def formatLine(e):
-    
+
         filename = formatEntry(e)
-        
+
         return f'{filename: <30} ({fileUrl(filename)})'
-    
-    
+
+
     return formatLine
 
 
 def printDir(entries : [DirEntry], wesUrl):
     '''
     $ wes get https://tes.tsi.ebi.ac.uk/data/tmp/0PR0GE/
-    
+
     tmp2ri6hb_r/        (file://data/tmp/0PR0GE/tmp2ri6hb_r/)
     tmp6awdshnf/        (file://data/tmp/0PR0GE/tmp.../)
     tmp_a_c9ltp/        (file://data/tmp/0PR0GE/tmp.../)
     tmppeev59oa/        (file://data/tmp/0PR0GE/tmp.../)
     '''
-    
+
     formatLine = newFormatLine(wesUrl)
-    
+
     print('\n'.join([formatLine(e) for e in entries]))
 
 
 def _get(wesUrl):
     '''
-    $ curl -H 'Accept: application/json' https://tes.tsi.ebi.ac.uk/data/tmp/ | json_pp 
-    
+    $ curl -H 'Accept: application/json' https://tes.tsi.ebi.ac.uk/data/tmp/ | json_pp
+
     [
        {
           "Mode" : 2151678445,
@@ -103,37 +103,45 @@ def _get(wesUrl):
 
     '''
     r = requests.get(wesUrl, headers = {'Accept': 'application/json'})
-    
+
 #     print(r)
-    
+
     r.raise_for_status()
-    
+
     return r
 
 
 def getCmd(wesUrl):
-    
+
     r = _get(wesUrl)
 
     contentType = r.headers['Content-Type']
-    
-    if contentType.startswith('application/json')   : printDir(r.json(), wesUrl) 
+
+    if contentType.startswith('application/json')   : printDir(r.json(), wesUrl)
     else                                            : print(r.text)
 
-    
+
 def cat(fileUrl) -> str:
-    
+
     return _get(fileUrl).text
 
 
 def ls(dirUrl) -> List[DirEntry]:
-    
+
     return _get(dirUrl).json()
 
 
-def download(url, progress=False):
+def download(url, progress=False, destination=False):
+
     CHUNK_SIZE = 64 * 1024
-    file_name = url.split('/')[-1]
+    if destination:
+        if os.path.isdir(destination):
+            org_file_name = url.split('/')[-1]
+            file_name = destination + '/' + org_file_name
+        else:
+            file_name = destination
+    else:
+        file_name = url.split('/')[-1]
     rq = requests.get(url, stream=True)
 
     if progress:

--- a/src/WesCli/Main.py
+++ b/src/WesCli/Main.py
@@ -27,7 +27,7 @@ def _main(args):
     if   opts['run']    :    run_multiple(opts['<runSpec>'])
     elif opts['get']    :    getCmd(opts['<url>'])
     elif opts['upload'] :    upload(opts['<filename>'], opts['<url>'])
-    elif opts['download'] :  download(opts['<url>'], opts['-p'])
+    elif opts['download'] :  download(opts['<url>'], opts['--progress'], opts['--destination'])
     elif opts['status'] :
 
         if hasWatch(opts) : os.system('watch -n 1 -d wes status')


### PR DESCRIPTION
-d --destination parameter allows user to specify a filename and location for downloaded file to be sent to

wes download --destination ./examples/hi.txt https://tes1.tsi.ebi.ac.uk/data/tmp/Hello.txt

This will create a hi.txt file in the examples sub-directory 

wes download --destination hi.txt https://tes1.tsi.ebi.ac.uk/data/tmp/Hello.txt

This will create a hi.txt file in the current directory 

wes download --destination ./examples https://tes1.tsi.ebi.ac.uk/data/tmp/Hello.txt

While this will send the downloaded Hello.txt file to the examples sub-directory preserving its pre-existing filename

README.md, ArgParser.py, Main.py and Get.py have been updated to accommodate and demonstrate this new parameter
