### PR TITLE
Pip install using setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/EMBL-EBI-TSI/WesCli.svg?token=u11Aix2T7c5M2Hxs5pyA&branch=master)](https://travis-ci.com/EMBL-EBI-TSI/WesCli)
 
 
-## Installation
+## Installation (Creating a new virtual environment)
 
 1. Requirements
 
@@ -50,7 +50,17 @@
     ```
     (or: edit `./install` and run it)
 
+## Installation (into an existing virtual enviornment)
 
+1. Requirements 
+
+    * Existing virtual environment (Python 3.6+)
+
+2. Pip install this repository
+    ```
+    pip install -e git+https://github.com/EMBL-EBI-TSI/WesCli#egg=WesCli
+    ```
+    
 ## Usage and examples
 
 Here's what you can do so far:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,17 @@ setup(
     version = "1.0",
     packages = find_packages('src'),
     package_dir = {'':'src'},
-    
+    python_requires=">=3.6",
+    install_requires=[
+        "pyyaml",
+        "requests",
+        "docopt",
+        "pydash",
+        "funcy",
+        "mypy",
+        "nose",
+        "progressbar2"
+    ],
 
     entry_points = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     package_dir = {'':'src'},
     python_requires=">=3.6",
     install_requires=[
+        "e1839a8",
         "pyyaml",
         "requests",
         "docopt",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     package_dir = {'':'src'},
     python_requires=">=3.6",
     install_requires=[
-        "e1839a8",
         "pyyaml",
         "requests",
         "docopt",


### PR DESCRIPTION
setup.py file updated to include Python and dependency requirements to allow WesCli to be installed directly using pip install:
python_requires=">=3.6",
install_requires=[
"pyyaml",
"requests",
"docopt",
"pydash",
"funcy",
"mypy",
"nose",
"progressbar2"
],
 ```
pip install -e git+https://github.com/EMBL-EBI-TSI/WesCli#egg=WesCli
```
This allows WesCli to be used in existing Python 3 environments without creating a new one 

README.md has been updated to show requirements and command need to install WesCli using pip install